### PR TITLE
Try to not rebuild the base image and download it instead.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,4 +31,6 @@ jobs:
       - name: Build all images
         run: |
           make -f Makefile.multi docker-all
+          docker pull docker.io/fyneio/fyne-cross-images:v1.1.4-base
+          touch .base
           make android-push

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,6 +31,5 @@ jobs:
       - name: Build all images
         run: |
           make -f Makefile.multi docker-all
-          docker pull docker.io/fyneio/fyne-cross-images:v1.1.4-base
-          touch .base
+          make base-pull
           make android-push

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,10 @@ windows: base
 
 all: base android darwin darwin-sdk-extractor freebsd linux windows web
 
+base-pull:
+	@$(RUNNER) pull ${REPOSITORY}:${VERSION}-base
+	touch .base
+
 android-push: android
 	@$(RUNNER) push ${REPOSITORY}:${VERSION}-android
 	@$(RUNNER) push ${REPOSITORY}:android


### PR DESCRIPTION
When building the android image, we currently don't have it locally as buildx multiplatform automatically push it and does not make it available locally. This is trying to download locally the amd64 v1.1.4-base image that was just build for multi target and reuse it for building the android image.