### PR TITLE
Update Go to 1.21.8 and Fyne to v2.4.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,9 @@ jobs:
           - os: web
           - os: freebsd
             arch: -amd64
-          - os: freebsd
-            arch: -arm64
+# Calculator build is failing on CI
+#          - os: freebsd
+#            arch: -arm64
 
     steps:
       - name: Setup Go environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,8 @@ jobs:
           - os: web
           - os: freebsd
             arch: -amd64
-# Current test failing
-#          - os: freebsd
-#            arch: -arm64
+          - os: freebsd
+            arch: -arm64
 
     steps:
       - name: Setup Go environment

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -4,7 +4,7 @@ ENV GO_VERSION=1.21.8
 # dev version of Zig to support windows-386 target
 # see: https://github.com/ziglang/zig/pull/13569
 ENV ZIG_VERSION=0.11.0-dev.2935+ec6ffaa1e
-ENV FYNE_VERSION=v2.4.1
+ENV FYNE_VERSION=v2.4.4
 ENV FIXUID_VERSION=0.5.1
 
 # Install common dependencies

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim AS base
 
-ENV GO_VERSION=1.21.1
+ENV GO_VERSION=1.21.8
 # dev version of Zig to support windows-386 target
 # see: https://github.com/ziglang/zig/pull/13569
 ENV ZIG_VERSION=0.11.0-dev.2935+ec6ffaa1e
@@ -35,11 +35,11 @@ RUN set -eux; \
     case "$arch" in \
         'amd64') \
             url="https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz";\
-            sha256='b3075ae1ce5dab85f89bc7905d1632de23ca196bd8336afd93fa97434cfa55ae'; \
+            sha256='538b3b143dc7f32b093c8ffe0e050c260b57fc9d57a12c4140a639a8dd2b4e4f'; \
             ;; \
         'arm64') \
             url="https://go.dev/dl/go${GO_VERSION}.linux-arm64.tar.gz";\
-            sha256='7da1a3936a928fd0b2602ed4f3ef535b8cd1990f1503b8d3e1acc0fa0759c967'; \
+            sha256='3c19113c686ffa142e9159de1594c952dee64d5464965142d222eab3a81f1270'; \
             ;; \
         *) echo >&2 "error: unsupported architecture '$arch'"; exit 1 ;; \
     esac; \

--- a/freebsd/amd64/Dockerfile
+++ b/freebsd/amd64/Dockerfile
@@ -7,10 +7,10 @@ FROM ${FYNE_CROSS_REPOSITORY}:${FYNE_CROSS_IMAGES_VERSION}-freebsd-base as pkg
 # Download FreeBSD base, extract libs/includes, pkg keys and configs
 # and install fyne dependencies
 # Based on: https://github.com/myfreeweb/docker-freebsd-cross/tree/fc70196f62c00a10eb61a45a4798e09214e0cdfd
-ENV ABI="FreeBSD:12:amd64"
+ENV ABI="FreeBSD:13:amd64"
 RUN mkdir /freebsd \
     && mkdir /etc/pkg/ \
-	&& curl https://download.freebsd.org/ftp/releases/amd64/12.4-RELEASE/base.txz | \
+	&& curl https://download.freebsd.org/ftp/releases/amd64/13.3-RELEASE/base.txz | \
 		bsdtar -xf - -C /freebsd ./lib ./usr/lib ./usr/libdata ./usr/include ./usr/share/keys ./etc \
     && cp /freebsd/etc/pkg/FreeBSD.conf /etc/pkg/ \
     && ln -s /freebsd/usr/share/keys /usr/share/keys 

--- a/freebsd/arm64/Dockerfile
+++ b/freebsd/arm64/Dockerfile
@@ -7,10 +7,10 @@ FROM ${FYNE_CROSS_REPOSITORY}:${FYNE_CROSS_IMAGES_VERSION}-freebsd-base as pkg
 # Download FreeBSD base, extract libs/includes, pkg keys and configs
 # and install fyne dependencies
 # Based on: https://github.com/myfreeweb/docker-freebsd-cross/tree/fc70196f62c00a10eb61a45a4798e09214e0cdfd
-ENV ABI="FreeBSD:12:aarch64"
+ENV ABI="FreeBSD:13:aarch64"
 RUN mkdir /freebsd \
     && mkdir /etc/pkg/ \
-	&& curl https://download.freebsd.org/ftp/releases/arm64/12.4-RELEASE/base.txz | \
+	&& curl https://download.freebsd.org/ftp/releases/arm64/13.3-RELEASE/base.txz | \
 		bsdtar -xf - -C /freebsd ./lib ./usr/lib ./usr/libdata ./usr/include ./usr/share/keys ./etc \
     && cp /freebsd/etc/pkg/FreeBSD.conf /etc/pkg/ \
     && ln -s /freebsd/usr/share/keys /usr/share/keys 


### PR DESCRIPTION
Update to latest stable versions for Go 1.21.x and Fyne v2.4.x. Not updating to Go 1.22.1 because it only contained security patches over 1.22.0 and i don't deem that ready for mass deployment yet.