### PR TITLE
Add wayland development dependency

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -19,6 +19,8 @@ RUN set -eux; \
         libxcursor-dev:amd64 \
         libxinerama-dev:amd64 \
          # deps to support wayland
+        libglfw3-dev:amd64 \
+        libgles2-mesa-dev:amd64 \
         libwayland-dev:amd64 \
         libxkbcommon-dev:amd64 \
         libdecor-0-dev:amd64 \
@@ -32,6 +34,8 @@ RUN set -eux; \
         libxcursor-dev:arm64 \
         libxinerama-dev:arm64 \
          # deps to support wayland
+        libglfw3-dev:arm64 \
+        libgles2-mesa-dev:arm64 \
         libwayland-dev:arm64 \
         libxkbcommon-dev:arm64 \
         libdecor-0-dev:arm64 \
@@ -45,6 +49,8 @@ RUN set -eux; \
         libxcursor-dev:armhf \
         libxinerama-dev:armhf \
          # deps to support wayland
+        libglfw3-dev:armhf \
+        libgles2-mesa-dev:armhf \
         libwayland-dev:armhf \
         libxkbcommon-dev:armhf \
         libdecor-0-dev:armhf \
@@ -58,6 +64,8 @@ RUN set -eux; \
         libxcursor-dev:i386 \
         libxinerama-dev:i386 \
          # deps to support wayland
+        libglfw3-dev:i386 \
+        libgles2-mesa-dev:i386 \
         libwayland-dev:i386 \
         libxkbcommon-dev:i386 \
         libdecor-0-dev:i386 \

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -19,7 +19,6 @@ RUN set -eux; \
         libxcursor-dev:amd64 \
         libxinerama-dev:amd64 \
          # deps to support wayland
-        libglfw3-dev:amd64 \
         libgles2-mesa-dev:amd64 \
         libwayland-dev:amd64 \
         libxkbcommon-dev:amd64 \
@@ -34,7 +33,6 @@ RUN set -eux; \
         libxcursor-dev:arm64 \
         libxinerama-dev:arm64 \
          # deps to support wayland
-        libglfw3-dev:arm64 \
         libgles2-mesa-dev:arm64 \
         libwayland-dev:arm64 \
         libxkbcommon-dev:arm64 \
@@ -49,7 +47,6 @@ RUN set -eux; \
         libxcursor-dev:armhf \
         libxinerama-dev:armhf \
          # deps to support wayland
-        libglfw3-dev:armhf \
         libgles2-mesa-dev:armhf \
         libwayland-dev:armhf \
         libxkbcommon-dev:armhf \
@@ -64,7 +61,6 @@ RUN set -eux; \
         libxcursor-dev:i386 \
         libxinerama-dev:i386 \
          # deps to support wayland
-        libglfw3-dev:i386 \
         libgles2-mesa-dev:i386 \
         libwayland-dev:i386 \
         libxkbcommon-dev:i386 \

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -19,6 +19,7 @@ RUN set -eux; \
         libxcursor-dev:amd64 \
         libxinerama-dev:amd64 \
          # deps to support wayland
+        libc6:amd64 \
         libglfw3-dev:amd64 \
         libgles2-mesa-dev:amd64 \
         libwayland-dev:amd64 \
@@ -34,6 +35,7 @@ RUN set -eux; \
         libxcursor-dev:arm64 \
         libxinerama-dev:arm64 \
          # deps to support wayland
+        libc6:arm64 \
         libglfw3-dev:arm64 \
         libgles2-mesa-dev:arm64 \
         libwayland-dev:arm64 \
@@ -49,6 +51,7 @@ RUN set -eux; \
         libxcursor-dev:armhf \
         libxinerama-dev:armhf \
          # deps to support wayland
+        libc6:armhf \
         libglfw3-dev:armhf \
         libgles2-mesa-dev:armhf \
         libwayland-dev:armhf \
@@ -64,6 +67,7 @@ RUN set -eux; \
         libxcursor-dev:i386 \
         libxinerama-dev:i386 \
          # deps to support wayland
+        libc6:i386 \
         libglfw3-dev:i386 \
         libgles2-mesa-dev:i386 \
         libwayland-dev:i386 \

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -19,7 +19,6 @@ RUN set -eux; \
         libxcursor-dev:amd64 \
         libxinerama-dev:amd64 \
          # deps to support wayland
-        libc6:amd64 \
         libglfw3-dev:amd64 \
         libgles2-mesa-dev:amd64 \
         libwayland-dev:amd64 \
@@ -35,7 +34,6 @@ RUN set -eux; \
         libxcursor-dev:arm64 \
         libxinerama-dev:arm64 \
          # deps to support wayland
-        libc6:arm64 \
         libglfw3-dev:arm64 \
         libgles2-mesa-dev:arm64 \
         libwayland-dev:arm64 \
@@ -51,7 +49,6 @@ RUN set -eux; \
         libxcursor-dev:armhf \
         libxinerama-dev:armhf \
          # deps to support wayland
-        libc6:armhf \
         libglfw3-dev:armhf \
         libgles2-mesa-dev:armhf \
         libwayland-dev:armhf \
@@ -67,7 +64,6 @@ RUN set -eux; \
         libxcursor-dev:i386 \
         libxinerama-dev:i386 \
          # deps to support wayland
-        libc6:i386 \
         libglfw3-dev:i386 \
         libgles2-mesa-dev:i386 \
         libwayland-dev:i386 \

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -19,6 +19,7 @@ RUN set -eux; \
         libxcursor-dev:amd64 \
         libxinerama-dev:amd64 \
          # deps to support wayland
+        libwayland-dev:amd64 \
         libxkbcommon-dev:amd64 \
         libdecor-0-dev:amd64 \
     ; \
@@ -31,6 +32,7 @@ RUN set -eux; \
         libxcursor-dev:arm64 \
         libxinerama-dev:arm64 \
          # deps to support wayland
+        libwayland-dev:arm64 \
         libxkbcommon-dev:arm64 \
         libdecor-0-dev:arm64 \
     ; \
@@ -43,6 +45,7 @@ RUN set -eux; \
         libxcursor-dev:armhf \
         libxinerama-dev:armhf \
          # deps to support wayland
+        libwayland-dev:armhf \
         libxkbcommon-dev:armhf \
         libdecor-0-dev:armhf \
     ; \
@@ -55,6 +58,7 @@ RUN set -eux; \
         libxcursor-dev:i386 \
         libxinerama-dev:i386 \
          # deps to support wayland
+        libwayland-dev:i386 \
         libxkbcommon-dev:i386 \
         libdecor-0-dev:i386 \
     ; \


### PR DESCRIPTION
Trying to address:
```
# github.com/go-gl/glfw/v3.4/glfw
In file included from /go/pkg/mod/github.com/go-gl/glfw/v3.4/glfw@v0.1.0-pre.1.0.20260707082822-2a407d02d01a/native_linbsd_wayland.go:10:
./glfw/include/GLFW/glfw3native.h:144:12: fatal error: 'EGL/egl.h' file not found
  144 |   #include <EGL/egl.h>
      |            ^~~~~~~~~~~
1 error generated.
```